### PR TITLE
Added a DelayFilter to prevent sending messages faster than allowed.

### DIFF
--- a/jtoggl-api/src/main/java/ch/simas/jtoggl/util/DelayFilter.java
+++ b/jtoggl-api/src/main/java/ch/simas/jtoggl/util/DelayFilter.java
@@ -1,0 +1,38 @@
+package ch.simas.jtoggl.util;
+
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientRequest;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.filter.ClientFilter;
+
+/**
+ * A ClientFilter implementation that delays for a fixed period of time before allowing the next
+ * filter to be called. This can be used to throttle every request sent to an API endpoint with rate
+ * limitations, or to perhaps as a simple simulation of network issues.
+ * 
+ * @author cewing
+ *
+ */
+public class DelayFilter extends ClientFilter {
+
+	private long throttlePeriod;
+
+	public DelayFilter(long throttlePeriod) {
+		if (throttlePeriod <= 0L) {
+			throw new IllegalArgumentException("Must be positive throttlePeriod");
+		}
+		this.throttlePeriod = throttlePeriod;
+	}
+
+	@Override
+	public ClientResponse handle(ClientRequest cr) throws ClientHandlerException {
+		try {
+			Thread.sleep(throttlePeriod);
+		} catch (InterruptedException e) {
+			// ignore, except to propagate
+			Thread.currentThread().interrupt();
+		}
+		return getNext().handle(cr);
+	}
+
+}

--- a/jtoggl-api/src/test/java/ch/simas/jtoggl/JTogglTest.java
+++ b/jtoggl-api/src/test/java/ch/simas/jtoggl/JTogglTest.java
@@ -73,6 +73,7 @@ public class JTogglTest {
         } catch (Exception e) {
             // Ignore because Task is only for paying customers
         }
+        jToggl.destroyProject(project.getId());
     }
 
     @Test
@@ -174,13 +175,12 @@ public class JTogglTest {
 
     @Test
     public void updateClient() {
-        final String NAME = "ABC";
 
-        client.setName(NAME);
+        client.setNotes("Making more notes for update! " + new Date());
         Client cl = jToggl.updateClient(client);
 
         Assert.assertNotNull(cl);
-        Assert.assertEquals(NAME, cl.getName());
+        Assert.assertEquals(client.getNotes(), cl.getNotes());
     }
 
     @Test
@@ -206,10 +206,16 @@ public class JTogglTest {
 
     @Test
     public void getTasks() {
+    	boolean isPremium = false;
+    	List<Workspace> workspaces = jToggl.getWorkspaces();
+    	if (!workspaces.isEmpty())
+    	{
+    		isPremium = workspaces.get(0).getPremium();
+    	}
         List<Task> tasks = jToggl.getTasks();
 
         // TODO Task is only available in payed version
-        //Assert.assertFalse(tasks.isEmpty());
+        Assert.assertFalse(isPremium && tasks.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
The Toggl API has some rate limits built in. I was receiving HTTP 429
(too many requests) when I ran the full suite, which indicated the tests
were running fast enough that we hit the rate limit on requests before
they finished. Also refactored some of the constants to make them easier
to adjust in case the paths change in the API, and added a check for
premium flag on the workspace for working with a Task (premium feature
only.

Added destroyProject, and added call to it in the JUnit afterClass().